### PR TITLE
Fix category and plan selectors layout

### DIFF
--- a/src/components/CategorySelector.tsx
+++ b/src/components/CategorySelector.tsx
@@ -12,7 +12,7 @@ export function CategorySelector({ selected, onToggle }: Props) {
           <motion.div key={cat.id} whileHover={{ scale: 1.03 }} whileTap={{ scale: 0.97 }}>
             <ToggleGroupItem
               value={cat.id}
-              className={`py-2 px-3 rounded text-sm font-medium focus:ring-2 focus:ring-offset-1 focus:ring-slate-400 ${
+              className={`py-2 px-3 rounded text-sm font-medium whitespace-normal break-words focus:ring-2 focus:ring-offset-1 focus:ring-slate-400 ${
                 selected.includes(cat.id)
                   ? 'bg-slate-600 text-white'
                   : 'bg-white text-slate-700 border border-slate-300'

--- a/src/components/PlanSelector.tsx
+++ b/src/components/PlanSelector.tsx
@@ -1,4 +1,4 @@
-import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import { motion } from 'framer-motion'
 
 type Props = { premium: boolean; onChange: (p: boolean) => void }
@@ -6,16 +6,17 @@ export function PlanSelector({ premium, onChange }: Props) {
   return (
     <div className="mb-4">
       <p className="block text-sm font-medium mb-2">Plan Type</p>
-      <RadioGroup
+      <ToggleGroup
+        type="single"
         value={premium ? 'premium' : 'standard'}
         onValueChange={val => onChange(val === 'premium')}
-        className="flex gap-2"
+        className="grid grid-cols-2 gap-2"
       >
         {['standard', 'premium'].map(type => (
           <motion.div key={type} whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
-            <RadioGroupItem
+            <ToggleGroupItem
               value={type}
-              className={`flex-1 py-2 px-4 rounded text-center font-medium focus:ring-2 focus:ring-offset-1 focus:ring-slate-400 ${
+              className={`py-2 px-4 rounded text-center font-medium focus:ring-2 focus:ring-offset-1 focus:ring-slate-400 ${
                 {
                   standard: !premium,
                   premium,
@@ -25,10 +26,10 @@ export function PlanSelector({ premium, onChange }: Props) {
               }`}
             >
               {type.charAt(0).toUpperCase() + type.slice(1)}
-            </RadioGroupItem>
+            </ToggleGroupItem>
           </motion.div>
         ))}
-      </RadioGroup>
+      </ToggleGroup>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- prevent category options from overlapping by allowing text wrapping
- show labels for plan type selector using toggle group instead of radio buttons

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
